### PR TITLE
Update Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ categories = ["asynchronous", "database"]
 [dependencies]
 bytes = "1.0"
 crossbeam = "0.8.1"
-flate2 = { version = "1.0", features = ["zlib"], default-features = false }
+flate2 = { version = "1.0", features = ["rust_backend"], default-features = false }
 futures-core = "0.3"
 futures-util = "0.3"
 futures-sink = "0.3"


### PR DESCRIPTION
Usage of zlib backend for flate2 causes a compilation failure. One should use a rust_backend instead.